### PR TITLE
Feature/rep 39778 adding http client to mfs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-config/local.json
+
 
 # Runtime data
 pids

--- a/app.js
+++ b/app.js
@@ -26,7 +26,7 @@ if (config.has('rtpengine')) {
   srf.use('invite', (req, res, next) => {
     const ctype = req.get('Content-Type') || '';
     if (!ctype.includes('multipart/mixed')) {
-      logger.info(`rejecting non-SIPREC INVITE with call-id ${req.get('Call-ID')}`);
+      logger.info(`rejecting non-SIPREC INVITE with call-id ${req.get('Call-ID')} and Cisco-Guid ${req.get('Cisco-Guid')}`);
       return res.send(488);
     }
     next();

--- a/config/local.json
+++ b/config/local.json
@@ -1,0 +1,14 @@
+{
+  "drachtio": {
+    "host": "127.0.0.1",
+    "port": 9022,
+    "secret": "cymru"
+  },
+  "rtpengine" : {
+    "remote": {
+      "host": "127.0.0.1",
+      "port": 22222
+    },
+    "localPort": 22222
+  }
+}

--- a/lib/http_call_control.js
+++ b/lib/http_call_control.js
@@ -1,0 +1,35 @@
+require('dotenv').config();
+const axios = require('axios');
+
+const SERVICE = "MFS"
+const EXTERNAL_SERVICES = "External-Services"
+
+const REQUEST_BASE_URL = `${process.env.MFS_PROTOCOL}://${process.env.MFS_URL}:${process.env.MFS_PORT}/${SERVICE}/${EXTERNAL_SERVICES}`
+
+const START_CALL_RECORDING_PIPELINE_REQUEST_URL = `${REQUEST_BASE_URL}/StartCallRecordingPipelineRequest`
+const STOP_CALL_RECORDING_PIPELINE_REQUEST_URL = `${REQUEST_BASE_URL}/StopCallRecordingPipelineRequest`
+
+let axios_headers_config = {
+    'Content-Type': 'application/json',
+    auth: {
+        username: process.env.MFS_API_USER_ID,
+        password: process.env.MFS_API_PASSWORD
+    }
+}
+
+exports.sendStartPipelineRequest = (sip_rec_app_logger, payload) => {
+    axios.post(START_CALL_RECORDING_PIPELINE_REQUEST_URL, payload, axios_headers_config)
+    .then((response) => {
+        const http_code = response.status;
+        const mfs_status = response.data.status; 
+        if (http_code == 200 && mfs_status) {
+            sip_rec_app_logger.info("[CARBYNE][HTTP-API] Successfully sent call properties to MFS application")
+        } else {
+            const { cause } = response.data;
+            sip_rec_app_logger.info(`[CARBYNE][HTTP-API] Failed to send call properties to MFS application: http_status_code=${http_code}, cause=${cause}`)
+        }
+    })
+    .catch((error) => {
+        sip_rec_app_logger.error(error);
+    });
+}

--- a/lib/rtpengine-call-handler.js
+++ b/lib/rtpengine-call-handler.js
@@ -81,7 +81,12 @@ function respondToInvite(opts) {
   sdpParser.getAllocatedPorts(opts.rtpengineCallerSdp, opts.rtpengineCalleeSdp)
   .then(([callerPort, calleePort]) => {
       opts.logger.info(`[CARBYNE] Extracted ports successfully : caller=${callerPort}, callee=${calleePort}, callID(Cisco-Guid)=${opts.req.get('Cisco-Guid')}`);
-      mfsAPI.sendStartPipelineRequest(opts.logger, callerPort, calleePort);
+      mfsAPI.sendStartPipelineRequest(opts.logger, 
+      {
+          'recordingID':  String(opts.req.get('Cisco-Guid')),
+          'callerPort': Number(callerPort),
+          'calleePort': Number(calleePort)
+      });
   })
   .catch(error => {
       opts.logger.error(error);

--- a/lib/rtpengine-call-handler.js
+++ b/lib/rtpengine-call-handler.js
@@ -84,8 +84,8 @@ function respondToInvite(opts) {
       mfsAPI.sendStartPipelineRequest(opts.logger, 
       {
           'recordingID':  String(opts.req.get('Cisco-Guid')),
-          'callerPort': Number(callerPort),
-          'calleePort': Number(calleePort)
+          'ingressStreamPort': Number(callerPort),
+          'egressStreamPort': Number(calleePort)
       });
   })
   .catch(error => {

--- a/lib/rtpengine-call-handler.js
+++ b/lib/rtpengine-call-handler.js
@@ -28,13 +28,25 @@ module.exports = (req, res) => {
     .then(allocateEndpoint.bind(null, 'callee', rtpEngine))
     .then(respondToInvite)
     .then((dlg) => {
-      logger.info(`call connected successfully, using rtpengine at ${JSON.stringify(rtpEngine.remote)}`);
-      return dlg.on('destroy', onCallEnd.bind(null, rtpEngine, opts));
+        logger.info(`call connected successfully, using rtpengine at ${JSON.stringify(rtpEngine.remote)}`);
+        /****************  CARBYNE START SECTION  ********************/
+        stopRTPSession(rtpEngine, opts);
+        /******************  CARBYNE END SECTION  ********************/
+        return dlg.on('destroy', onCallEnd.bind(null, rtpEngine, opts));
     })
     .catch((err) => {
       logger.error(`Error connecting call: ${err}`);
     });
 };
+
+/****************  CARBYNE START SECTION  ********************/
+function stopRTPSession(rtpEngine, opts) {
+    opts.logger.info(`[CARBYNE] Stopping RTPEngine for callID(Cisco-Guid)=${opts.callDetails['call-id']}`)
+    rtpEngine.delete(rtpEngine.remote, opts.callDetails).then((response) => {
+        opts.logger.info(`[CARBYNE] Closed RTPEngine response : ${JSON.stringify(response)}`);
+    });
+} 
+/******************  CARBYNE END SECTION  ********************/
 
 function allocateEndpoint(which, rtpEngine, opts) {
   const args = Object.assign({metadata: JSON.stringify({'Cisco-Guid': gcid})}, opts.callDetails, {
@@ -64,9 +76,7 @@ function respondToInvite(opts) {
 }
 
 function onCallEnd(rtpEngine, opts) {
-  opts.logger.info('call ended');
-  return rtpEngine.delete(rtpEngine.remote, opts.callDetails)
-    .then((response) => {
-      return debug(`response to rtpengine delete: ${JSON.stringify(response)}`);
-    });
+    /****************  CARBYNE START SECTION  ********************/
+    opts.logger.info(`[CARBYNE] SIP-REC Call dialog has ended: rtpEngine=${rtpEngine}`);
+    /******************  CARBYNE END SECTION  ********************/
 }

--- a/lib/rtpengine-call-handler.js
+++ b/lib/rtpengine-call-handler.js
@@ -57,7 +57,7 @@ function allocateEndpoint(which, rtpEngine, opts) {
     'sdp': which === 'caller' ? opts.sdp1 : opts.sdp2,
     'replace': ['origin', 'session-connection'],
     'ICE': 'remove',
-    'record call': 'yes'
+    'record call': 'no'
   });
   if (which === 'callee') Object.assign(args, {'to-tag': uuidv4()});
 

--- a/lib/rtpengine-call-handler.js
+++ b/lib/rtpengine-call-handler.js
@@ -3,7 +3,11 @@ const constructSiprecPayload = require('./payload-combiner');
 const {getAvailableRtpengine} = require('./utils');
 const uuidv4 = require('uuid/v4');
 const debug = require('debug')('drachtio:siprec-recording-server');
+/****************  CARBYNE START SECTION  ********************/
+const mfsAPI = require('./http_call_control');
+const sdpParser = require('./rtpengine-sdp-parser-helpers');
 var gcid;
+/******************  CARBYNE END SECTION  ********************/
 
 module.exports = (req, res) => {
   gcid = req.get('Cisco-Guid');
@@ -72,6 +76,18 @@ function allocateEndpoint(which, rtpEngine, opts) {
 function respondToInvite(opts) {
   const srf = opts.req.srf;
   const payload = constructSiprecPayload(opts.rtpengineCallerSdp, opts.rtpengineCalleeSdp);
+  
+  /****************  CARBYNE START SECTION  ********************/
+  sdpParser.getAllocatedPorts(opts.rtpengineCallerSdp, opts.rtpengineCalleeSdp)
+  .then(([callerPort, calleePort]) => {
+      opts.logger.info(`[CARBYNE] Extracted ports successfully : caller=${callerPort}, callee=${calleePort}, callID(Cisco-Guid)=${opts.req.get('Cisco-Guid')}`);
+      mfsAPI.sendStartPipelineRequest(opts.logger, callerPort, calleePort);
+  })
+  .catch(error => {
+      opts.logger.error(error);
+  });
+  /******************  CARBYNE END SECTION  ********************/
+  
   return srf.createUAS(opts.req, opts.res, {localSdp: payload});
 }
 

--- a/lib/rtpengine-call-handler.js
+++ b/lib/rtpengine-call-handler.js
@@ -93,6 +93,6 @@ function respondToInvite(opts) {
 
 function onCallEnd(rtpEngine, opts) {
     /****************  CARBYNE START SECTION  ********************/
-    opts.logger.info(`[CARBYNE] SIP-REC Call dialog has ended: rtpEngine=${rtpEngine}`);
+    opts.logger.info(`[CARBYNE] SIP-REC Call dialog has ended: callID(Cisco-Guid)=${opts.req.get('Cisco-Guid')}, rtpEngine=${rtpEngine}`);
     /******************  CARBYNE END SECTION  ********************/
 }

--- a/lib/rtpengine-call-handler.js
+++ b/lib/rtpengine-call-handler.js
@@ -3,9 +3,11 @@ const constructSiprecPayload = require('./payload-combiner');
 const {getAvailableRtpengine} = require('./utils');
 const uuidv4 = require('uuid/v4');
 const debug = require('debug')('drachtio:siprec-recording-server');
+var gcid;
 
 module.exports = (req, res) => {
-  const callid = req.get('Call-ID');
+  gcid = req.get('Cisco-Guid');
+  const callid = req.get('Cisco-Guid');
   const from = req.getParsedHeader('From');
   const logger = req.srf.locals.logger.child({callid});
   const opts = {
@@ -35,7 +37,7 @@ module.exports = (req, res) => {
 };
 
 function allocateEndpoint(which, rtpEngine, opts) {
-  const args = Object.assign({}, opts.callDetails, {
+  const args = Object.assign({metadata: JSON.stringify({'Cisco-Guid': gcid})}, opts.callDetails, {
     'sdp': which === 'caller' ? opts.sdp1 : opts.sdp2,
     'replace': ['origin', 'session-connection'],
     'ICE': 'remove',

--- a/lib/rtpengine-sdp-parser-helpers.js
+++ b/lib/rtpengine-sdp-parser-helpers.js
@@ -1,0 +1,27 @@
+
+
+/* 
+    This helper function as its name helps to get from a string which represents an SDP the allocated port.
+    The passed SDP is created by RTPEngine.
+    The extraction of the port is used by regex pattern matching
+    Example of sdp: 
+    v=0\r\no=CiscoSystemsSIP-GW-UserAgent 1017 6183 IN IP4 172.31.19.1\r\ns=SIP Call\r\nc=IN IP4 172.31.19.1\r\nt=0 0\r\nm=audio 19578 RTP/AVP 8 101 100\r\nc=IN IP4 172.31.19.1\r\na=label:1\r\na=rtpmap:8 PCMA/8000\r\na=rtpmap:101 telephone-event/8000\r\na=rtpmap:100 X-NSE/8000\r\na=fmtp:101 0-16\r\na=fmtp:100 192-194\r\na=sendonly\r\na=rtcp:19579\r\na=ptime:20\r\n
+*/
+exports.getAllocatedPorts = (rtpengineCallerSDP, rtpengineCalleeSDP) => {
+    return new Promise((resolve, reject) => {
+        const regexPattern = /m=audio \d* RTP/;
+        const callerResult = rtpengineCallerSDP.match(regexPattern);
+        const calleeResult = rtpengineCalleeSDP.match(regexPattern);
+
+        if (callerResult.length !== 1 || calleeResult.length !== 1) {
+            reject(`[CARBYNE][SDP-PARSER] Couldn't get allocated ports of the call out of RTPEngine allocated SDPs: callerSDP=${rtpengineCallerSDP}\n, calleeSDP=${rtpengineCalleeSDP}`);
+        } else {
+            const callerSplittedResult = callerResult[0].split(' ');
+            const calleeSplittedResult = calleeResult[0].split(' ');
+            if (callerSplittedResult.length !== 3 || calleeSplittedResult.length !== 3) {
+                reject(`[CARBYNE][SDP-PARSER] RTPEngine allocated SDPs 'maudio' section is not in expected format: callerSDP=${rtpengineCallerSDP}\n, calleeSDP=${rtpengineCalleeSDP}`);
+            }
+            resolve([Number(callerSplittedResult[1]), Number(calleeSplittedResult[1])]);
+        }
+    });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -112,6 +112,14 @@
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
     },
+    "axios": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "requires": {
+        "follow-redirects": "1.5.10"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -374,9 +382,9 @@
       }
     },
     "dotenv": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.0.0.tgz",
-      "integrity": "sha512-FlWbnhgjtwD+uNLUGHbMykMOYQaTivdHEmYwAKFjn6GKe/CqY0fNae93ZHTd20snh9ZLr8mTzIL9m0APQ1pjQg==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
+      "integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==",
       "dev": true
     },
     "double-ended-queue": {
@@ -771,6 +779,14 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.5.tgz",
       "integrity": "sha1-W0UbCMvUji6sVKK74L9GFlqhS+M="
+    },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "requires": {
+        "debug": "=3.1.0"
+      }
     },
     "for-each": {
       "version": "0.3.3",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "blue-tape": "^1.0.0",
     "clear-require": "^2.0.0",
-    "dotenv": "^6.0.0",
+    "dotenv": "^6.2.0",
     "eslint": "^5.10.0",
     "eslint-plugin-promise": "^4.0.1",
     "fs-extra": "^5.0.0",
@@ -41,6 +41,7 @@
     "tape": "^4.9.1"
   },
   "dependencies": {
+    "axios": "^0.19.2",
     "config": "^1.30.0",
     "debug": "^3.1.0",
     "drachtio-srf": "^4.4.31",


### PR DESCRIPTION
Includes the following:

- SDP Parser for fetching the ports of the allocated SDP by RTPEngine himself.
- HTTP module which sends after fetching the ports(using the SDP Parser) and send them to the configured MFS URL.
- Updated RTPEngine call handler which prints logs for getting more info about the call so we could use the logs of SIPREC in our CloudWatch in a better and faster way to investigate errors.