### PR TITLE
Feature/rep 47314 ingess and egress

### DIFF
--- a/lib/rtpengine-call-handler.js
+++ b/lib/rtpengine-call-handler.js
@@ -103,7 +103,7 @@ function initiateMFSNewCall(opts) {
     let calleeAOR = JSON.stringify(opts.callee, null, 2);
 
     if(xIngressLabel) {
-        const isCallerResult = isSDPWithMatchingIngressLabel(xIngressLabel, opts.rtpengineCallerSdp);
+        const isCallerResult = isSDPWithMatchingIngressLabel(xIngressLabel, rtpEngineCallerSDP);
         if (typeof isCallerResult === "boolean") {
             if (!isCallerResult) {
                 rtpEngineCallerSDP = opts.rtpengineCalleeSdp;
@@ -152,14 +152,7 @@ function isSDPWithMatchingIngressLabel(xIngressLabel, rtpengineParticipantSDP) {
 }
 
 function getSIPHeaderValue(opts, headerName) {
-    let headerValue = opts.req.get(headerName);
-    if (!headerValue) {
-        headerValue = opts.req.get(headerName.toUpperCase());
-        if (!headerValue) {
-            return opts.req.get(headerName.toLowerCase());
-        }
-    }
-    return headerValue;
+    return opts.req.get(headerName);
 }
 
 function hasCallValidProperties(callerPort, calleePort, callerCodec, callerClockRate, calleeCodec, calleeClockRate) {

--- a/lib/rtpengine-call-handler.js
+++ b/lib/rtpengine-call-handler.js
@@ -8,6 +8,7 @@ const mfsAPI = require('./http_call_control');
 const sdpParser = require('./rtpengine-sdp-parser-helpers');
 var gcid;
 
+const X_INGRESS_LABEL = "X-Ingress-Label";
 const CODEC_PCMA = "pcma";
 const CODEC_PCMU = "pcmu";
 const MIN_PORT = 0;
@@ -80,21 +81,42 @@ function allocateEndpoint(which, rtpEngine, opts) {
 }
 
 function respondToInvite(opts) {
-  const srf = opts.req.srf;
-  const payload = constructSiprecPayload(opts.rtpengineCallerSdp, opts.rtpengineCalleeSdp);
-  
-  /****************  CARBYNE START SECTION  ********************/
-  initiateMFSNewCall(opts);
-  opts.logger.info(`[CARBYNE][SIP-REC] Responding to INVITE with OK: call-id=${opts.req.get('Call-ID')}, Cisco-Guid=${opts.req.get('Cisco-Guid')}, caller=${JSON.stringify(opts.caller, null, 2)}, callee=${JSON.stringify(opts.callee, null, 2)}, rtpengineCallerSdp=${opts.rtpengineCallerSdp}, rtpengineCalleeSdp=${opts.rtpengineCalleeSdp}`);
-  /******************  CARBYNE END SECTION  ********************/
-  
-  return srf.createUAS(opts.req, opts.res, {localSdp: payload});
+    const srf = opts.req.srf;
+    const payload = constructSiprecPayload(opts.rtpengineCallerSdp, opts.rtpengineCalleeSdp);
+    
+    /****************  CARBYNE START SECTION  ********************/
+    initiateMFSNewCall(opts);
+    opts.logger.info(`[CARBYNE][SIP-REC] Responding to INVITE with OK: call-id=${opts.req.get('Call-ID')}, Cisco-Guid=${opts.req.get('Cisco-Guid')}, caller=${JSON.stringify(opts.caller, null, 2)}, callee=${JSON.stringify(opts.callee, null, 2)}, rtpengineCallerSdp=${opts.rtpengineCallerSdp}, rtpengineCalleeSdp=${opts.rtpengineCalleeSdp}`);
+    /******************  CARBYNE END SECTION  ********************/
+    
+    return srf.createUAS(opts.req, opts.res, {localSdp: payload});
 }
 
 /****************  CARBYNE START SECTION  ********************/
 function initiateMFSNewCall(opts) {
-    const getCallPortsPromise = sdpParser.getAllocatedPorts(opts.rtpengineCallerSdp, opts.rtpengineCalleeSdp);
-    const getCodecsAndClockRatePromise = sdpParser.getCodecAndClockRate(opts.rtpengineCallerSdp, opts.rtpengineCalleeSdp);
+
+    const xIngressLabel = opts.req.get(X_INGRESS_LABEL);
+
+    let getCallPortsPromise;
+    let getCodecsAndClockRatePromise;
+
+    const isCallerResult = isCaller(opts, xIngressLabel, opts.rtpengineCallerSdp);
+    
+    if(xIngressLabel) {
+        if (typeof isCallerResult === "boolean") {
+            if (isCallerResult) {
+                getCallPortsPromise = sdpParser.getAllocatedPorts(opts.rtpengineCallerSdp, opts.rtpengineCalleeSdp);
+                getCodecsAndClockRatePromise = sdpParser.getCodecAndClockRate(opts.rtpengineCallerSdp, opts.rtpengineCalleeSdp);
+                opts.logger.info(`[CARBYNE][SIP-REC] Sides of the call for the session are: callerSDP=${opts.rtpengineCallerSdp}, calleeSDP=${opts.rtpengineCalleeSdp}, call-id=${opts.req.get('Call-ID')}, Cisco-Guid=${opts.req.get('Cisco-Guid')}`);
+            } else {
+                getCallPortsPromise = sdpParser.getAllocatedPorts(opts.rtpengineCalleeSdp, opts.rtpengineCallerSdp);
+                getCodecsAndClockRatePromise = sdpParser.getCodecAndClockRate(opts.rtpengineCalleeSdp, opts.rtpengineCallerSdp);
+                opts.logger.info(`[CARBYNE][SIP-REC] Sides of the call for the session are: callerSDP=${opts.rtpengineCalleeSdp}, calleeSDP=${opts.rtpengineCallerSdp}, call-id=${opts.req.get('Call-ID')}, Cisco-Guid=${opts.req.get('Cisco-Guid')}`);
+            }
+        } else {
+            console.log(`Exception received: exception=${isCallerResult}`)
+        }
+    }
     
     Promise.all([getCallPortsPromise, getCodecsAndClockRatePromise]).then(([[callerPort, calleePort], [callerCodec, callerClockRate, calleeCodec, calleeClockRate]]) => {
         const validationError = hasCallValidProperties(callerPort, calleePort, callerCodec, callerClockRate, calleeCodec, calleeClockRate);
@@ -116,6 +138,18 @@ function initiateMFSNewCall(opts) {
     }).catch(error => {
         console.log(error);
     });
+}
+
+function isCaller(opts, xIngressLabel, rtpengineParticipantSDP) {
+    var regexPattern = new RegExp(`a=label:${xIngressLabel}`);
+    const matchResult = rtpengineCallerSDP.match(regexPattern);
+    
+    var regexPattern = new RegExp(`a=label:${whichLabel}`, 'gi');
+    try {
+        return rtpengineParticipantSDP.match(regexPattern);
+    } catch (e) {
+        return e;
+    }
 }
 
 function hasCallValidProperties(callerPort, calleePort, callerCodec, callerClockRate, calleeCodec, calleeClockRate) {

--- a/lib/rtpengine-call-handler.js
+++ b/lib/rtpengine-call-handler.js
@@ -86,7 +86,6 @@ function respondToInvite(opts) {
     
     /****************  CARBYNE START SECTION  ********************/
     initiateMFSNewCall(opts);
-    opts.logger.info(`[CARBYNE][SIP-REC] Responding to INVITE with OK: call-id=${opts.req.get('Call-ID')}, Cisco-Guid=${opts.req.get('Cisco-Guid')}, caller=${JSON.stringify(opts.caller, null, 2)}, callee=${JSON.stringify(opts.callee, null, 2)}, rtpengineCallerSdp=${opts.rtpengineCallerSdp}, rtpengineCalleeSdp=${opts.rtpengineCalleeSdp}`);
     /******************  CARBYNE END SECTION  ********************/
     
     return srf.createUAS(opts.req, opts.res, {localSdp: payload});
@@ -94,29 +93,32 @@ function respondToInvite(opts) {
 
 /****************  CARBYNE START SECTION  ********************/
 function initiateMFSNewCall(opts) {
-
-    const xIngressLabel = opts.req.get(X_INGRESS_LABEL);
-
+    const xIngressLabel = getSIPHeaderValue(opts, X_INGRESS_LABEL);
+    
     let getCallPortsPromise;
     let getCodecsAndClockRatePromise;
+    let rtpEngineCallerSDP = opts.rtpengineCallerSdp;
+    let rtpEngineCalleeSDP = opts.rtpengineCalleeSdp;
+    let callerAOR = JSON.stringify(opts.caller, null, 2);
+    let calleeAOR = JSON.stringify(opts.callee, null, 2);
 
-    const isCallerResult = isCaller(opts, xIngressLabel, opts.rtpengineCallerSdp);
-    
     if(xIngressLabel) {
+        const isCallerResult = isSDPWithMatchingIngressLabel(xIngressLabel, opts.rtpengineCallerSdp);
         if (typeof isCallerResult === "boolean") {
-            if (isCallerResult) {
-                getCallPortsPromise = sdpParser.getAllocatedPorts(opts.rtpengineCallerSdp, opts.rtpengineCalleeSdp);
-                getCodecsAndClockRatePromise = sdpParser.getCodecAndClockRate(opts.rtpengineCallerSdp, opts.rtpengineCalleeSdp);
-                opts.logger.info(`[CARBYNE][SIP-REC] Sides of the call for the session are: callerSDP=${opts.rtpengineCallerSdp}, calleeSDP=${opts.rtpengineCalleeSdp}, call-id=${opts.req.get('Call-ID')}, Cisco-Guid=${opts.req.get('Cisco-Guid')}`);
-            } else {
-                getCallPortsPromise = sdpParser.getAllocatedPorts(opts.rtpengineCalleeSdp, opts.rtpengineCallerSdp);
-                getCodecsAndClockRatePromise = sdpParser.getCodecAndClockRate(opts.rtpengineCalleeSdp, opts.rtpengineCallerSdp);
-                opts.logger.info(`[CARBYNE][SIP-REC] Sides of the call for the session are: callerSDP=${opts.rtpengineCalleeSdp}, calleeSDP=${opts.rtpengineCallerSdp}, call-id=${opts.req.get('Call-ID')}, Cisco-Guid=${opts.req.get('Cisco-Guid')}`);
+            if (!isCallerResult) {
+                rtpEngineCallerSDP = opts.rtpengineCalleeSdp;
+                rtpEngineCalleeSDP = opts.rtpengineCallerSdp;
+                callerAOR = JSON.stringify(opts.callee, null, 2);
+                calleeAOR = JSON.stringify(opts.caller, null, 2);
             }
         } else {
-            console.log(`Exception received: exception=${isCallerResult}`)
+            opts.logger.error(`[CARBYNE][SIPREC] Exception received while trying to figure out whose the caller using X-Ingress-Label header: exception=${isCallerResult}`);
         }
-    }
+    } 
+
+    getCallPortsPromise = sdpParser.getAllocatedPorts(rtpEngineCallerSDP, rtpEngineCalleeSDP);
+    getCodecsAndClockRatePromise = sdpParser.getCodecAndClockRate(rtpEngineCallerSDP, rtpEngineCalleeSDP);
+    opts.logger.info(`[CARBYNE][SIP-REC] Sides of the call for the session are: xIngressLabel=${xIngressLabel}, callerSDP=${rtpEngineCallerSDP}, callerAOR=${callerAOR}, calleeSDP=${rtpEngineCalleeSDP}, calleeAOR=${calleeAOR}, call-id=${opts.req.get('Call-ID')}, Cisco-Guid=${opts.req.get('Cisco-Guid')}`);
     
     Promise.all([getCallPortsPromise, getCodecsAndClockRatePromise]).then(([[callerPort, calleePort], [callerCodec, callerClockRate, calleeCodec, calleeClockRate]]) => {
         const validationError = hasCallValidProperties(callerPort, calleePort, callerCodec, callerClockRate, calleeCodec, calleeClockRate);
@@ -136,20 +138,28 @@ function initiateMFSNewCall(opts) {
             opts.logger.error(`[CARBYNE][SDP-PARSER] Couldn't receive call properties properly [${validationError}] for: call-id=${opts.req.get('Call-ID')}, Cisco-Guid=${opts.req.get('Cisco-Guid')}`);
         }
     }).catch(error => {
-        console.log(error);
+        opts.logger.error(error);
     });
 }
 
-function isCaller(opts, xIngressLabel, rtpengineParticipantSDP) {
-    var regexPattern = new RegExp(`a=label:${xIngressLabel}`);
-    const matchResult = rtpengineCallerSDP.match(regexPattern);
-    
-    var regexPattern = new RegExp(`a=label:${whichLabel}`, 'gi');
+function isSDPWithMatchingIngressLabel(xIngressLabel, rtpengineParticipantSDP) {
     try {
-        return rtpengineParticipantSDP.match(regexPattern);
+        var regexPattern = new RegExp(`a=label:${xIngressLabel}`, 'gi');
+        return rtpengineParticipantSDP.match(regexPattern) != null;
     } catch (e) {
         return e;
     }
+}
+
+function getSIPHeaderValue(opts, headerName) {
+    let headerValue = opts.req.get(headerName);
+    if (!headerValue) {
+        headerValue = opts.req.get(headerName.toUpperCase());
+        if (!headerValue) {
+            return opts.req.get(headerName.toLowerCase());
+        }
+    }
+    return headerValue;
 }
 
 function hasCallValidProperties(callerPort, calleePort, callerCodec, callerClockRate, calleeCodec, calleeClockRate) {


### PR DESCRIPTION
This PR was already tests in DEV-EXP environment.
I've seen that after answering the call, in the logs the ports are switched.

In addition, in the PCAP itself, I've also matched the port in which was chosen to be the ingress to be sent to MFS by playback the relative port in Wireshark.

The relevant port which was chosen as ingress was my smartphone side of the call.

Moreover, the code was tested out with sipp for other edge cases that the code handles.